### PR TITLE
add github-metadata plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,3 +111,8 @@ google:
 skill_software_keywords: [Java, C++, Python, Design Patterns]
 skill_mobile_app_keywords: [Android, Reverse Engineering]
 skill_windows_keywords: [Win32 SDK, DuiLib, WTL, COM, WinDbg]
+
+# ---------------- #
+# Github metadata  #
+# ---------------- #
+gems: ['jekyll-github-metadata','jekyll-paginate']


### PR DESCRIPTION
幸不辱命

增加离线 github-metadata 支持
插件使用参见 [github-metadata](https://github.com/jekyll/github-metadata)