### PR TITLE
增加离线 Github 仓库支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,4 +115,5 @@ skill_windows_keywords: [Win32 SDK, DuiLib, WTL, COM, WinDbg]
 # ---------------- #
 # Github metadata  #
 # ---------------- #
-gems: ['jekyll-github-metadata','jekyll-paginate']
+gems: ['jekyll-github-metadata','jekyll-paginate','jekyll-feed']
+repository: mzlogin/mzlogin.github.io

--- a/_config.yml
+++ b/_config.yml
@@ -111,3 +111,8 @@ google:
 skill_software_keywords: [Java, C++, Python, Design Patterns]
 skill_mobile_app_keywords: [Android, Reverse Engineering]
 skill_windows_keywords: [Win32 SDK, DuiLib, WTL, COM, WinDbg]
+
+# ---------------- #
+# Github metadata  #
+# ---------------- #
+gems: ['jekyll-github-metadata','jekyll-paginate']


### PR DESCRIPTION
增加离线 github-metadata 支持
插件使用参见 [github-metadata](https://github.com/jekyll/github-metadata)

同时发现不自动生成 feed.xml，加了一个 feed 插件