### PR TITLE
单引号错误

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -92,7 +92,7 @@
         <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
         <script>
         var gitalk = new Gitalk({
-            id: '{{ page.url | truncate: 50, '' }}',
+            id: '{{ page.url | truncate: 50, "" }}',
             clientID: '{{ site.gitalk.clientID }}',
             clientSecret: '{{ site.gitalk.clientSecret }}',
             repo: '{{ site.gitalk.repo }}',


### PR DESCRIPTION
当只使用gitalk的时候，这个地方的格式错误会导致gitalk加载失败。