### PR TITLE
Fix: one extra button in paginator.

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,10 +151,12 @@ comments: false
           <button disabled="disabled" href="javascript:;" class="btn btn-outline">...</button>
         {% endif %}
 
-        {% if paginator.page == paginator.total_pages %}
-            <a href="jaavascript:;" class="active btn btn-outline">{{paginator.total_pages}}</a>
-        {% else %}
-            <a href="{{ site.url }}/page{{paginator.total_pages}}"  class="btn btn-outline">{{paginator.total_pages}}</a>
+        {% if paginator.total_pages > 1 %}
+          {% if paginator.page == paginator.total_pages %}
+              <a href="jaavascript:;" class="active btn btn-outline">{{paginator.total_pages}}</a>
+          {% else %}
+              <a href="{{ site.url }}/page{{paginator.total_pages}}"  class="btn btn-outline">{{paginator.total_pages}}</a>
+          {% endif %}
         {% endif %}
 
         {% if paginator.next_page %}


### PR DESCRIPTION
When the total page number is 1, the paginator containers two buttons all referenced to the page1.

Before fix:
![image](https://user-images.githubusercontent.com/28183761/188263702-fe767446-9a26-43e5-83c7-3866e924e25b.png)

After fix:
![image](https://user-images.githubusercontent.com/28183761/188263729-8b590023-b571-4fc3-a35f-1d2b68afd9a7.png)
