### PR TITLE
Update jquery.toc.js

### DIFF
--- a/assets/js/jquery.toc.js
+++ b/assets/js/jquery.toc.js
@@ -69,7 +69,7 @@
       if (this_level === level) {// same level as before; same indenting
         html += "<li class=\"toc-item toc-level-" + this_level + "\">";
         html += "<a class=\"jumper\" href='#" + fixedEncodeURIComponent(header.id) + "'>";
-        html += "<span class='toc-text'>" + header.innerHTML + "</span>";
+        html += "<span class='toc-text'>" + header.textContent + "</span>";
         html += "</a>";
 
       } else if (this_level <= level){ // higher level than before; end parent ol
@@ -77,7 +77,7 @@
           html += "</li></"+settings.listType+">"
         }
         html += "<li class='toc-item toc-level-" + this_level + "'><a class=\"jumper\" href='#" + fixedEncodeURIComponent(header.id) + "'>";
-        html += "<span class='toc-text'>" + header.innerHTML + "</span>";
+        html += "<span class='toc-text'>" + header.textContent + "</span>";
         html += "</a>";
       }
       else if (this_level > level) { // lower level than before; expand the previous to contain a ol
@@ -85,7 +85,7 @@
           html += "<"+settings.listType+" class='toc-child'><li class='toc-item toc-level-" + i + "'>"
         }
         html += "<a class=\"jumper\" href='#" + fixedEncodeURIComponent(header.id) + "'>";
-        html += "<span class='toc-text'>" + header.innerHTML + "</span>";
+        html += "<span class='toc-text'>" + header.textContent + "</span>";
         html += "</a>";
       }
       level = this_level; // update for the next one


### PR DESCRIPTION
参见 https://sawtone.github.io/2024/08/25/how-i-change-my-blog

在各级标题内添加的超链接会与 JS 添加的锚点发生冲突

导致用户点击时会优先执行标题自带的超链接跳转到外部网站，将原本的锚点跳转覆盖掉

修改三处：innerHTML->textContent